### PR TITLE
Add Docker setup and workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+client/node_modules
+server/node_modules
+client/dist
+.git

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,21 @@
+name: Docker
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t gpt-store .
+      - name: Run container
+        run: |
+          docker run -d --name gpt-store -p 4000:4000 gpt-store
+          sleep 5
+          curl -f http://localhost:4000/api/health
+          docker stop gpt-store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+package-lock.json
+*.db
+
+# Ignore local env files
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use official Node.js LTS image
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Install server dependencies
+COPY server/package*.json ./server/
+RUN cd server && npm install --omit=dev
+
+# Copy server source
+COPY server ./server
+
+# Expose port and start server
+WORKDIR /app/server
+EXPOSE 4000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ npm run dev
 ```
 Client runs at **http://localhost:5173**.
 
+### 3) Docker
+```bash
+docker build -t gpt-store .
+docker run -p 4000:4000 gpt-store
+```
+The container exposes the API at **http://localhost:4000**.
+
 ## Features
 - Product catalog + search/filter
 - Add to Cart, Cart Drawer, Checkout (mock payment selection)

--- a/server/server.js
+++ b/server/server.js
@@ -175,6 +175,11 @@ app.delete('/api/admin/products/:id', authRequired, adminRequired, (req, res) =>
 // Health
 app.get('/api/health', (_req, res) => res.json({ ok: true }));
 
+// Root
+app.get('/', (_req, res) => {
+  res.send('GPT Store API is running');
+});
+
 app.listen(PORT, () => {
   console.log(`GPT Store server running on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add Dockerfile to run Node server
- document Docker usage in README
- build and smoke-test image via GitHub Actions
- ignore temporary files for cleaner builds
- serve a friendly message on `/` so hitting the root URL no longer returns `Cannot GET /

## Testing
- `npm test` *(fails: Missing script "test")*
- `docker build -t gpt-store .` *(fails: command not found)*
- `npm start` & `curl http://localhost:4000/` *(200 OK: `GPT Store API is running`)*

------
https://chatgpt.com/codex/tasks/task_e_689d0e8a649c8333bfe09e3870ac7738