### PR TITLE
Add product detail page and improve product image workflow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import Login from './pages/Login'
 import Register from './pages/Register'
 import Checkout from './pages/Checkout'
 import Admin from './pages/Admin'
+import Product from './pages/Product'
 
 function Navbar() {
   const { user, logout } = useAuth()
@@ -16,12 +17,17 @@ function Navbar() {
     <div className="nav">
       <div className="container flex">
         <Link className="brand neon-title" to="/">GPT Store</Link>
-        <div className="space" />
         <Link to="/">Home</Link>
         {user?.is_admin && <Link to="/admin">Admin</Link>}
+        <div className="space" />
         {!user && <Link to="/login">Login</Link>}
         {!user && <Link to="/register">Register</Link>}
-        {user && <span className="badge">Hi, {user.name}</span>}
+        {user && (
+          <div className="row" style={{alignItems:'center'}}>
+            <span style={{fontSize:18}}>👤</span>
+            <span>{user.name}</span>
+          </div>
+        )}
         {user && <button className="ghost" onClick={() => { logout(); navigate('/'); }}>Logout</button>}
         <button onClick={open}>Cart</button>
       </div>
@@ -41,6 +47,7 @@ export default function App() {
             <Route path="/register" element={<Register />} />
             <Route path="/checkout" element={<Checkout />} />
             <Route path="/admin" element={<Admin />} />
+            <Route path="/products/:id" element={<Product />} />
           </Routes>
         </div>
       </CartProvider>

--- a/client/src/components/ProductCard.jsx
+++ b/client/src/components/ProductCard.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { useCart } from '../context/CartContext'
+import { useNavigate } from 'react-router-dom'
 
 export default function ProductCard({ product }) {
   const { add } = useCart()
+  const navigate = useNavigate()
   return (
-    <div className="card">
+    <div className="card product-card" onClick={() => navigate(`/products/${product.id}`)}>
       <div style={{height:160, background:'#0d0d0d', borderRadius:12, marginBottom:12, display:'flex', alignItems:'center', justifyContent:'center', border:'1px solid #1f1f1f'}}>
         <span style={{opacity:0.8}}>{product.image ? <img src={product.image} alt={product.title} style={{maxHeight:150, maxWidth:'100%', borderRadius:12}}/> : product.title.substring(0,1)}</span>
       </div>
@@ -14,7 +16,7 @@ export default function ProductCard({ product }) {
         <div style={{fontSize:18, fontWeight:800}}>${product.price.toFixed(2)}</div>
         <div className="badge">{product.category}</div>
         <div className="space" />
-        <button onClick={() => add(product, 1)}>Add to Cart</button>
+        <button style={{minWidth:120}} onClick={(e) => { e.stopPropagation(); add(product, 1) }}>Add to Cart</button>
       </div>
     </div>
   )

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -31,11 +31,20 @@ button {
   font-weight: 700;
   box-shadow: var(--shadow);
   cursor: pointer;
+  transition: transform 0.1s, filter 0.2s;
+  white-space: nowrap;
 }
 button.ghost {
   background: #000;
   color: var(--accent);
   border: 1px solid var(--accent);
+}
+button:hover {
+  transform: scale(1.05);
+}
+button:active {
+  transform: scale(0.95);
+  filter: brightness(0.9);
 }
 input, select, textarea {
   background: #0e0e0e;
@@ -52,6 +61,13 @@ input, select, textarea {
   border-radius: 16px;
   padding: 16px;
   box-shadow: var(--shadow);
+}
+.product-card {
+  transition: transform 0.2s;
+  cursor: pointer;
+}
+.product-card:hover {
+  transform: scale(1.02);
 }
 .grid {
   display: grid;

--- a/client/src/pages/Admin.jsx
+++ b/client/src/pages/Admin.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import ProtectedRoute from '../components/ProtectedRoute'
 import { AdminAPI, ProductAPI } from '../api'
 
@@ -10,6 +10,7 @@ export default function Admin() {
   const [form, setForm] = useState(empty)
   const [editingId, setEditingId] = useState(null)
   const [error, setError] = useState('')
+  const fileRef = useRef()
 
   const load = async () => {
     try {
@@ -72,7 +73,18 @@ export default function Admin() {
                 </select>
                 <input placeholder="Stock" value={form.stock} onChange={e=>setForm({...form, stock:e.target.value})} />
               </div>
-              <input placeholder="Image URL (optional)" value={form.image} onChange={e=>setForm({...form, image:e.target.value})} />
+              <div className="row" style={{alignItems:'center'}}>
+                <button type="button" className="ghost" onClick={() => fileRef.current.click()}>Upload Image</button>
+                <input type="file" accept="image/*" ref={fileRef} style={{display:'none'}} onChange={e => {
+                  const file = e.target.files[0]
+                  if (file) {
+                    const reader = new FileReader()
+                    reader.onloadend = () => setForm({...form, image: reader.result})
+                    reader.readAsDataURL(file)
+                  }
+                }} />
+                {form.image && <img src={form.image} alt="preview" style={{height:40, borderRadius:8}} />}
+              </div>
               <div className="row">
                 <button onClick={save}>{editingId ? 'Update' : 'Create'}</button>
                 {editingId && <button className="ghost" onClick={() => { setForm(empty); setEditingId(null) }}>Cancel</button>}

--- a/client/src/pages/Product.jsx
+++ b/client/src/pages/Product.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { ProductAPI } from '../api';
+import { useCart } from '../context/CartContext';
+
+export default function Product() {
+  const { id } = useParams();
+  const [product, setProduct] = useState(null);
+  const [error, setError] = useState('');
+  const { add } = useCart();
+
+  useEffect(() => {
+    ProductAPI.get(id)
+      .then(res => setProduct(res.product))
+      .catch(e => setError(e.message));
+  }, [id]);
+
+  if (error) return <div>{error}</div>;
+  if (!product) return <div>Loading...</div>;
+
+  return (
+    <div className="card">
+      <div className="row" style={{alignItems: 'flex-start'}}>
+        {product.image && (
+          <img src={product.image} alt={product.title} style={{maxWidth: 300, borderRadius: 12}} />
+        )}
+        <div style={{flex:1}}>
+          <div className="neon-title" style={{fontSize:24}}>{product.title}</div>
+          <p style={{opacity:0.8}}>{product.description}</p>
+          <div style={{fontWeight:800, fontSize:20}}>${product.price.toFixed(2)}</div>
+          <div className="badge">{product.category}</div>
+          <div style={{marginTop:12}}>
+            <button style={{minWidth:140}} onClick={() => add(product, 1)}>Add to Cart</button>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <div>
+        <div className="neon-title" style={{fontSize:20}}>Customer Reviews</div>
+        <p style={{opacity:0.8}}>No reviews yet.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow admins to upload product images via file picker with preview
- add interactive styling for buttons and cards and widen Add to Cart buttons
- enable clicking product cards to open a new product details page with reviews placeholder
- show a login icon next to the user name in the navigation bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d22b5e83c83338a795a1b3ee8e69d