### PR TITLE
refactor: enhance cart layout

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Routes, Route, Link, useNavigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './context/AuthContext'
 import { CartProvider, useCart } from './context/CartContext'
+import CartDrawer from './components/CartDrawer'
 import Home from './pages/Home'
 import Login from './pages/Login'
 import Register from './pages/Register'
@@ -50,6 +51,7 @@ export default function App() {
             <Route path="/products/:id" element={<Product />} />
           </Routes>
         </div>
+        <CartDrawer />
       </CartProvider>
     </AuthProvider>
   )

--- a/client/src/components/ProductCard.jsx
+++ b/client/src/components/ProductCard.jsx
@@ -7,16 +7,16 @@ export default function ProductCard({ product }) {
   const navigate = useNavigate()
   return (
     <div className="card product-card" onClick={() => navigate(`/products/${product.id}`)}>
-      <div style={{height:160, background:'#0d0d0d', borderRadius:12, marginBottom:12, display:'flex', alignItems:'center', justifyContent:'center', border:'1px solid #1f1f1f'}}>
-        <span style={{opacity:0.8}}>{product.image ? <img src={product.image} alt={product.title} style={{maxHeight:150, maxWidth:'100%', borderRadius:12}}/> : product.title.substring(0,1)}</span>
+      <div style={{height:160, background:'#0d0d0d', borderRadius:12, marginBottom:12, display:'flex', alignItems:'center', justifyContent:'center', border:'1px solid #1f1f1f', padding:8, overflow:'hidden'}}>
+        <span style={{opacity:0.8}}>{product.image ? <img src={product.image} alt={product.title} style={{maxHeight:150, maxWidth:'100%', borderRadius:12, objectFit:'contain'}}/> : product.title.substring(0,1)}</span>
       </div>
       <div className="neon-title" style={{fontSize:18}}>{product.title}</div>
       <div style={{opacity:0.8, margin:'6px 0 10px'}}>{product.description}</div>
-      <div className="row" style={{alignItems:'center'}}>
+      <div className="row" style={{alignItems:'center', flexWrap:'wrap'}}>
         <div style={{fontSize:18, fontWeight:800}}>${product.price.toFixed(2)}</div>
         <div className="badge">{product.category}</div>
         <div className="space" />
-        <button style={{minWidth:120}} onClick={(e) => { e.stopPropagation(); add(product, 1) }}>Add to Cart</button>
+        <button style={{minWidth:120, marginTop:8}} onClick={(e) => { e.stopPropagation(); add(product, 1) }}>Add to Cart</button>
       </div>
     </div>
   )

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { ProductAPI } from '../api'
 import ProductCard from '../components/ProductCard'
-import CartDrawer from '../components/CartDrawer'
 
 const categories = ['Mobile Phone', 'Laptop', 'PC', 'TV Screen', 'Addon']
 
@@ -43,7 +42,6 @@ export default function Home() {
           {products.map(p => <ProductCard key={p.id} product={p} />)}
         </div>
       )}
-      <CartDrawer />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- ensure cart drawer is available on every page
- improve product card padding so controls fit within the card
- remove duplicate cart drawer from home page

## Testing
- `npm test --prefix client` *(fails: Missing script "test")*
- `npm test --prefix server` *(fails: Missing script "test")*
- `npm run build --prefix client`
- `(node server/server.js > /tmp/server-run.log 2>&1 &) ; sleep 1; pkill node; tail -n 20 /tmp/server-run.log`


------
https://chatgpt.com/codex/tasks/task_e_689d27c00c9c8333a03e22c2e69a6a2b