### PR TITLE
Fix layout for user action buttons

### DIFF
--- a/client/src/pages/Admin.jsx
+++ b/client/src/pages/Admin.jsx
@@ -178,9 +178,11 @@ export default function Admin() {
                     <td>{u.name}</td>
                     <td>{u.email}</td>
                     <td>{u.is_admin ? 'Yes' : 'No'}</td>
-                    <td style={{textAlign:'right'}}>
-                      <button className="ghost" onClick={() => editUser(u)}>Edit</button>{' '}
-                      <button className="ghost" onClick={() => removeUser(u.id)}>Delete</button>
+                    <td>
+                      <div className="row" style={{justifyContent:'flex-end', gap:8}}>
+                        <button className="ghost" onClick={() => editUser(u)}>Edit</button>
+                        <button className="ghost" onClick={() => removeUser(u.id)}>Delete</button>
+                      </div>
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- Wrap Edit and Delete buttons in a flex row within the Users table to keep them inside their cell

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d329caa748333a9a7f615aef4fdab